### PR TITLE
fix the performance issue

### DIFF
--- a/src/lava/build.rs
+++ b/src/lava/build.rs
@@ -88,10 +88,13 @@ pub async fn build_lava_bm25(
         texts.push(text);
     }
 
-    let encodings = texts.into_maybe_par_iter().map(|text| {
-        let encoding = tokenizer.encode(text, true).unwrap();
-        encoding.get_ids().to_vec()
-    }).collect::<Vec<Vec<u32>>>();
+    let encodings = texts
+        .into_maybe_par_iter()
+        .map(|text| {
+            let encoding = tokenizer.encode(text, true).unwrap();
+            encoding.get_ids().to_vec()
+        })
+        .collect::<Vec<Vec<u32>>>();
 
     let mut inverted_index: Vec<BTreeMap<usize, f32>> = vec![BTreeMap::new(); vocab_size];
     let mut token_counts: Vec<usize> = vec![0; vocab_size];


### PR DESCRIPTION
```
(.venv) ➜  rottnest git:(master) ✗ time python test.py
Compressed token counts size: 61563 number of tokens: 30522
30522
None
python test.py  268.23s user 13.52s system 599% cpu 47.013 total 
```